### PR TITLE
Fix path to Sublime Text 2 Packages dir on OS X

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,17 +4,17 @@ A **TextMate Bundle** for the [**Elixir**](http://github.com/elixir-lang/elixir)
 
 ## Installation
 
-Type the following commands to setup the bundle for TextMate:
+Type the following commands to setup the bundle for **TextMate**:
 
     $ mkdir -p ~/Library/Application\ Support/TextMate/Bundles
     $ cd !$
     $ git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
     $ osascript -e 'tell app "TextMate" to reload bundles'
 
-If you are using Sublime Text 2, type the following commands in your shell:
+If you are using **Sublime Text 2**, type the following commands in your shell:
 
     $ cd ~/.config/sublime-text-2/Packages # If you are on Linux
-    $ cd ~/Library/Application\ Support/Sublime\ Text\ 2/ # If you are on Mac
+    $ cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages # If you are on Mac
     $ git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
 
 You can now use Elixir's color syntax in files. In some case, you should restart Sublime Text to make changes work.


### PR DESCRIPTION
Previously, the `/Packages` part at the end was accidentally omitted.
