### PR TITLE
Improved indentation for Sublime Text 2

### DIFF
--- a/Preferences/Indent.tmPreferences
+++ b/Preferences/Indent.tmPreferences
@@ -11,7 +11,7 @@
 		<key>decreaseIndentPattern</key>
 		<string>^\s*((\}|\])\s*$|(after|else|catch|rescue|end)\b)</string>
 		<key>increaseIndentPattern</key>
-		<string>(after|else|catch|rescue|\-\&gt;|\{|\[|do)\s*$</string>
+		<string>(after|else|catch|rescue|^.*(do|&lt;\-|\-&gt;|\{|\[))\s*$</string>
 	</dict>
 	<key>uuid</key>
 	<string>313112A0-FC40-4025-97AE-3E85DC0DB08F</string>


### PR DESCRIPTION
With this change a newline inserted after `do`, `{`, `<-` or `->` becomes indented.
_Note: a newline after_ `[` _still does not get indented._
