### PR TITLE
Add Scope to doc snippet

### DIFF
--- a/Snippets/doc.tmSnippet
+++ b/Snippets/doc.tmSnippet
@@ -8,6 +8,8 @@ $0
 """</string>
 	<key>name</key>
 	<string>doc</string>
+	<key>scope</key>
+	<string>source.elixir</string>
 	<key>tabTrigger</key>
 	<string>doc</string>
 	<key>uuid</key>


### PR DESCRIPTION
Add missing scope to doc snippet, it really interferes with Ruby.
