### PR TITLE
Added basic 'Run' command

### DIFF
--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>saveActiveFile</string>
+	<key>command</key>
+	<string>#!/usr/bin/env ruby -wKU
+require "#{ENV['TM_SUPPORT_PATH']}/lib/tm/save_current_document"
+require "#{ENV["TM_SUPPORT_PATH"]}/lib/tm/executor"
+
+TextMate.save_if_untitled('exs')
+TextMate::Executor.run(e_sh(ENV['TM_ELIXIR'] || 'elixir'), ENV['TM_FILEPATH'])
+</string>
+	<key>input</key>
+	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>@r</string>
+	<key>name</key>
+	<string>Run</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
+	<key>scope</key>
+	<string>source.elixir</string>
+	<key>uuid</key>
+	<string>06E4B9F0-06CD-4B95-822F-2CC67E3802C2</string>
+</dict>
+</plist>


### PR DESCRIPTION
Hello! 

Here is a basic 'Run' command classic 'Cmd + R' 
- I should have implemented the Regexps for parsing and correctly formatting the errors in the  TextMate output dialog when errors occur. Working on that :) 
- When the file has still not been saved TextMate will ask to save it before running I've added the call to TextMate function

``` ruby
TextMate.save_if_untitled('exs')
```

But for some reason Textmate is putting and 'ex' extension instead of the 'exs' probably a bug in TextMate support libraries. Working on that to :) 

But now you hit Cmd + R and there you go!
