### PR TITLE
Remove $ in README to make it easier to copy/paste instructions.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,24 +6,24 @@ A **TextMate Bundle** for the [**Elixir**](http://github.com/elixir-lang/elixir)
 
 Type the following commands to setup the bundle for **TextMate**:
 
-    $ mkdir -p ~/Library/Application\ Support/TextMate/Bundles
-    $ cd !$
-    $ git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
-    $ osascript -e 'tell app "TextMate" to reload bundles'
+    mkdir -p ~/Library/Application\ Support/TextMate/Bundles
+    cd !$
+    git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
+    osascript -e 'tell app "TextMate" to reload bundles'
 
 
 If you are using **TextMate 2**, type the following commands in your shell:
 
-    $ mkdir -p ~/Library/Application\ Support/Avian/Bundles
-    $ cd ~/Library/Application\ Support/Avian/Bundles
-    $ git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
+    mkdir -p ~/Library/Application\ Support/Avian/Bundles
+    cd ~/Library/Application\ Support/Avian/Bundles
+    git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
 
 
 If you are using **Sublime Text 2**, type the following commands in your shell:
 
-    $ cd ~/.config/sublime-text-2/Packages # If you are on Linux
-    $ cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages # If you are on Mac
-    $ git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
+    cd ~/.config/sublime-text-2/Packages # If you are on Linux
+    cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages # If you are on Mac
+    git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
 
 You can now use Elixir's color syntax in files. In some case, you should restart Sublime Text to make changes work.
 


### PR DESCRIPTION
The `$` is unnecessary in the code snippets and it's easier to copy the block of instructions and paste it into Terminal than go line by line.
