### PR TITLE
Fix #15 Indentation for else, rescue, etc.

### DIFF
--- a/Preferences/Indent.tmPreferences
+++ b/Preferences/Indent.tmPreferences
@@ -11,7 +11,7 @@
 		<key>decreaseIndentPattern</key>
 		<string>^\s*((\}|\])\s*$|(after|else|catch|rescue|end)\b)</string>
 		<key>increaseIndentPattern</key>
-		<string>(after|else|catch|rescue|^.*(do|&lt;\-|\-&gt;|\{|\[))\s*$</string>
+		<string>^\s*(after|else|catch|rescue|^.*(do|&lt;\-|\-&gt;|\{|\[))\s*$</string>
 	</dict>
 	<key>uuid</key>
 	<string>313112A0-FC40-4025-97AE-3E85DC0DB08F</string>


### PR DESCRIPTION
This minor change fixes the lack of auto-indenting after secondary clauses like else, rescue, and so on.

For Sublime Text, I believe one must restart in order for changes to the indentation rules to take effect.
I have not tried this out in TextMate - perhaps someone can, just to verify it hasn't broken anything there (it shouldn't).
