### PR TITLE
Fix double quoting issue in sublime 3 build system for windows

### DIFF
--- a/elixir.sublime-build
+++ b/elixir.sublime-build
@@ -2,6 +2,7 @@
 	"cmd": ["elixir", "$file"],
 	"selector": "source.elixir",
 	"windows": {
-		"cmd": ["elixir.bat", "$file"]
+    "working_dir": "$file_path",
+		"cmd": ["elixir.bat", "$file_name"]
 	}
 }


### PR DESCRIPTION
As stated in the issue, build system currently generates the following error in ST3 
<code>path\to\file.ex\""=="" was unexpected at this time</code>

Solved by using alternative build directives for sublime build system.
