### PR TITLE
Capture defp? as meta to get different coloring

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -55,7 +55,7 @@
                 </dict>
             </dict>
             <key>match</key>
-            <string>^\s*(defp?)\s+(([A-Za-z_]\w*\s*(\.)\s*)*[A-Za-z_]\w*)</string>
+            <string>^\s*(def(?:macro)?p?)\s+([a-z_]\w*)</string>
             <key>name</key>
             <string>meta.function.elixir</string>
         </dict>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -40,6 +40,25 @@
 			<key>name</key>
 			<string>meta.module.elixir</string>
 		</dict>
+        <dict>
+            <key>captures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.control.function.elixir</string>
+                </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>entity.name.type.function.elixir</string>
+                </dict>
+            </dict>
+            <key>match</key>
+            <string>^\s*(defp?)\s+(([A-Za-z_]\w*\s*(\.)\s*)*[A-Za-z_]\w*)</string>
+            <key>name</key>
+            <string>meta.function.elixir</string>
+        </dict>
 		<dict>
 			<key>begin</key>
 			<string>@(module|type)?doc (~[a-z])?"""</string>
@@ -839,10 +858,10 @@
 			?\n      ?\b
 
 			examples (3rd alternation = normal):
-			?a       ?A       ?0 
-			?*       ?"       ?( 
+			?a       ?A       ?0
+			?*       ?"       ?(
 			?.       ?#
-			
+
 			the negative lookbehind prevents against matching
 			p(42.tainted?)
 			</string>


### PR DESCRIPTION
Capture `def` and `defp` as meta in the language syntax to get different coloring. This is consistent with
how other languages such as Erlang and Python for instance color function names in their definition blocks in Sublime.

Note: I'm using a rather simplistic theme, so this might/might not affect other people.