### PR TITLE
Recognize elixir functions, macros and exunit tests as symbols.

### DIFF
--- a/Preferences/Function Symbols.tmPreferences
+++ b/Preferences/Function Symbols.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Function Symbols</string>
 	<key>scope</key>
-	<string>source.elixir.function.public</string>
+	<string>source.elixir.symbol</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Preferences/Function Symbols.tmPreferences
+++ b/Preferences/Function Symbols.tmPreferences
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Function Symbols</string>
+	<key>scope</key>
+	<string>source.elixir.function.public</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>symbolTransformation</key>
+		<string>s/^/ /</string>
+		<key>showInIndexedSymbolList</key>
+		<integer>1</integer>
+		<key>symbolIndexTransformation</key>
+		<string>s/^/ /</string>
+	</dict>
+</dict>
+</plist>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -55,7 +55,7 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>source.elixir.function.public</string>
+					<string>source.elixir.symbol</string>
 				</dict>
 				<key>3</key>
 				<dict>
@@ -66,7 +66,7 @@
   	</dict>		
 		<dict>
 			<key>name</key>
-			<string>source.elixir.function</string>
+			<string>source.elixir.macro</string>
 			<key>match</key>
 			<string>^\s*(defmacro[p]?)\s+(.*)[, ]\s*(do)</string>
 			<key>captures</key>
@@ -79,7 +79,7 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>source.elixir.function.public</string>
+					<string>source.elixir.symbol</string>
 				</dict>
 				<key>3</key>
 				<dict>
@@ -90,7 +90,7 @@
   	</dict>			
   	<dict>
 			<key>name</key>
-			<string>source.elixir.function</string>
+			<string>source.elixir.exunit.test</string>
 			<key>match</key>
 			<string>^\s*((test)\s+("[^"]+"))</string>
 			<key>captures</key>
@@ -98,7 +98,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>source.elixir.function.public</string>
+					<string>source.elixir.symbol</string>
 				</dict>				
 				<key>2</key>
 				<dict>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -41,6 +41,54 @@
 			<string>meta.module.elixir</string>
 		</dict>
 		<dict>
+			<key>name</key>
+			<string>source.elixir.function</string>
+			<key>match</key>
+			<string>^\s*(def[p]?)\s+(.*)[, ]\s*(do)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>source.elixir.function.public</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.elixir</string>
+				</dict>
+			</dict>
+  	</dict>		
+		<dict>
+			<key>name</key>
+			<string>source.elixir.function</string>
+			<key>match</key>
+			<string>^\s*(test)\s+("([^"]+)")</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.double.elixir</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>source.elixir.function.public</string>
+				</dict>				
+			</dict>
+  	</dict>			
+  	<dict>
 			<key>begin</key>
 			<string>@(module|type)?doc (~[a-z])?"""</string>
 			<key>comment</key>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -68,6 +68,30 @@
 			<key>name</key>
 			<string>source.elixir.function</string>
 			<key>match</key>
+			<string>^\s*(defmacro[p]?)\s+(.*)[, ]\s*(do)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>source.elixir.function.public</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.elixir</string>
+				</dict>
+			</dict>
+  	</dict>			
+  	<dict>
+			<key>name</key>
+			<string>source.elixir.function</string>
+			<key>match</key>
 			<string>^\s*((test)\s+("[^"]+"))</string>
 			<key>captures</key>
 			<dict>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -68,24 +68,24 @@
 			<key>name</key>
 			<string>source.elixir.function</string>
 			<key>match</key>
-			<string>^\s*(test)\s+("([^"]+)")</string>
+			<string>^\s*((test)\s+("[^"]+"))</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.control.elixir</string>
-				</dict>
+					<string>source.elixir.function.public</string>
+				</dict>				
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>string.quoted.double.elixir</string>
+					<string>keyword.control.elixir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>source.elixir.function.public</string>
-				</dict>				
+					<string>string.quoted.double.elixir</string>
+				</dict>
 			</dict>
   	</dict>			
   	<dict>


### PR DESCRIPTION

    
This allows to use `Goto Symbol...` (Cmd+[Shift]+R) to jump directly to a function, macro or exunit test 
and __improves navigation__ in elixir source files.
Functions/macros with __different signature/guards__ are listed as __separate items__ in the symbol list.