### PR TITLE
cd into root folder before running mix test

### DIFF
--- a/elixir-mix-test.sublime-build
+++ b/elixir-mix-test.sublime-build
@@ -1,5 +1,5 @@
 {
-    "cmd": ["mix", "test"],
+    "shell_cmd": "cd $folder && mix test",
     "working_dir": "${project_path}",
     "selector": "source.elixir"
 }


### PR DESCRIPTION
Right now the test build system does not really work when opening whole project directory in sublime.

```
** (Mix) Could not find a Mix.Project, please ensure a mix.exs file is available
[Finished in 0.4s with exit code 1]
[cmd: ['mix', 'test']]
[dir: /some/path/to/project/test]
```