### PR TITLE
Add function syntax

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -59,7 +59,7 @@
 			<key>contentName</key>
 			<string>variable.parameter.function.public.elixir</string>
 			<key>end</key>
-			<string>(\))|(do|when)</string>
+			<string>(\))|(do|when)|(,\s+(do:?))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -68,6 +68,11 @@
 					<string>punctuation.definition.parameters.elixir</string>
 				</dict>
 				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.module.elixir</string>
+				</dict>
+				<key>4</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.control.module.elixir</string>
@@ -102,7 +107,7 @@
 			<key>contentName</key>
 			<string>variable.parameter.function.private.elixir</string>
 			<key>end</key>
-			<string>(\))|(do|when)</string>
+			<string>(\))|(do|when)|(,\s+(do:?))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -111,6 +116,11 @@
 					<string>punctuation.definition.parameters.elixir</string>
 				</dict>
 				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.module.elixir</string>
+				</dict>
+				<key>4</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.control.module.elixir</string>
@@ -216,6 +226,12 @@
 					<string>#escaped_char</string>
 				</dict>
 			</array>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\sdo:\s</string>
+			<key>name</key>
+			<string>keyword.control.elixir</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -75,7 +75,7 @@
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.control.module.elixir</string>
+					<string>constant.other.keywords.elixir</string>
 				</dict>
 			</dict>
 			<key>name</key>
@@ -123,7 +123,7 @@
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.control.module.elixir</string>
+					<string>constant.other.keywords.elixir</string>
 				</dict>
 			</dict>
 			<key>name</key>
@@ -229,13 +229,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\sdo:\s</string>
-			<key>name</key>
-			<string>keyword.control.elixir</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\.)\b(do|end|case|bc|lc|for|if|cond|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defmacrop?|defdelegate|defcallback|defmacrocallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|import|require|alias|use|quote|unquote|super)\b(?![?!])</string>
+			<string>(?&lt;!\.)\b(do(?&gt;$|\s)|end|case|bc|lc|for|if|cond|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defmacrop?|defdelegate|defcallback|defmacrocallback|defexception|defoverridable|exit|after|rescue|catch|else(?&gt;$|\s)|raise|throw|import|require|alias|use|quote|unquote|super)\b(?![?!])</string>
 			<key>name</key>
 			<string>keyword.control.elixir</string>
 		</dict>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -42,7 +42,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(def)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))(?&gt;\(|\s*)</string>
+			<string>^\s*(def)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -55,11 +55,16 @@
 					<key>name</key>
 					<string>entity.name.function.public.elixir</string>
 				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.elixir</string>
+				</dict>
 			</dict>
 			<key>contentName</key>
 			<string>variable.parameter.function.public.elixir</string>
 			<key>end</key>
-			<string>(\))|(do|when)|(,\s+(do:?))</string>
+			<string>(\))|(do|when)|((,)\s+(do:?))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -73,6 +78,11 @@
 					<string>keyword.control.module.elixir</string>
 				</dict>
 				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.elixir</string>
+				</dict>
+				<key>5</key>
 				<dict>
 					<key>name</key>
 					<string>constant.other.keywords.elixir</string>
@@ -90,7 +100,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(defp)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))(?&gt;\(|\s*)</string>
+			<string>^\s*(defp)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -103,11 +113,16 @@
 					<key>name</key>
 					<string>entity.name.function.private.elixir</string>
 				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.elixir</string>
+				</dict>
 			</dict>
 			<key>contentName</key>
 			<string>variable.parameter.function.private.elixir</string>
 			<key>end</key>
-			<string>(\))|(do|when)|(,\s+(do:?))</string>
+			<string>(\))|(do|when)|((,)\s+(do:?))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -121,6 +136,11 @@
 					<string>keyword.control.module.elixir</string>
 				</dict>
 				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.elixir</string>
+				</dict>
+				<key>5</key>
 				<dict>
 					<key>name</key>
 					<string>constant.other.keywords.elixir</string>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -42,6 +42,92 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>^\s*(def)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))(?&gt;\(|\s*)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.module.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.public.elixir</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>variable.parameter.function.public.elixir</string>
+			<key>end</key>
+			<string>(\))|(do|when)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.module.elixir</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.function.public.elixir</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>^\s*(defp)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))(?&gt;\(|\s*)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.module.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.private.elixir</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>variable.parameter.function.private.elixir</string>
+			<key>end</key>
+			<string>(\))|(do|when)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.module.elixir</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.function.private.elixir</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>@(module|type)?doc (~[a-z])?"""</string>
 			<key>comment</key>
 			<string>@doc with heredocs is treated as documentation</string>
@@ -1026,7 +1112,6 @@
 				</dict>
 			</array>
 		</dict>
-
 		<key>nest_curly_and_self</key>
 		<dict>
 			<key>patterns</key>

--- a/info.plist
+++ b/info.plist
@@ -7,7 +7,6 @@
 	<key>ordering</key>
 	<array>
 		<string>BC7C8178-FD4F-4F5F-9F5A-07FDC25FE899</string>
-		<string>D00C06B9-71B2-4FEB-A0E3-37237F579456</string>
 		<string>313112A0-FC40-4025-97AE-3E85DC0DB08F</string>
 		<string>78D9FEF5-7439-4DAE-AEAC-E99E476CA7DF</string>
 		<string>B84C6EFA-2343-473E-84EC-78F8FBA7F54F</string>


### PR DESCRIPTION
Syntax highlighting has been added for both public and private functions.

Tested with:

```elixir
def foo, do: nil
def foo when true, do: [answer: 42]
def foo(a, b), do: a + b
def foo(a, b) when true, do: a
def foo a, b, do: a + b

def foo do
  nil
end

def foo when true do
  [answer: 42]
end

def foo(a, b) do
  if a > b, do: a, else: b
end

def foo(a, b) when true do
  a + b
end

def foo a, b do
  a + b
end

defp bar, do: nil
defp bar when true, do: [answer: 42]
defp bar(a, b), do: a + b
defp bar(a, b) when true, do: a
defp bar a, b, do: a + b

defp bar do
  nil
end

defp bar when true do
  [answer: 42]
end

defp bar(a, b) do
  if a > b, do: a, else: b
end

defp bar(a, b) when true do
  a + b
end

defp bar a, b do
  a + b
end
```