### PR TITLE
Add module reference syntax

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -263,6 +263,12 @@
 		</dict>
 		<dict>
 			<key>match</key>
+			<string>\b[A-Z]\w*\b</string>
+			<key>name</key>
+			<string>support.module.elixir</string>
+		</dict>
+		<dict>
+			<key>match</key>
 			<string>\b(nil|true|false)\b(?![?!])</string>
 			<key>name</key>
 			<string>constant.language.elixir</string>


### PR DESCRIPTION
Selector `support.module.elixir` matches module names outside their definitions.

For example, the matches in `GenServer.start(Agent.Server, fun, options)` would be `GenServer`, `Agent`, and `Server`.