### PR TITLE
Fix anonymous variable syntax

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -303,7 +303,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(&amp;)\d*</string>
+			<string>(&amp;)\d+</string>
 			<key>name</key>
 			<string>variable.other.anonymous.elixir</string>
 		</dict>


### PR DESCRIPTION
Selector `variable.other.anonymous.elixir` previously matched all ampersands, whether or not a numeral was to follow. Fixed to match only if numeral present.