### PR TITLE
Fix module highlighting

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -301,7 +301,7 @@
 			<key>match</key>
 			<string>\b[A-Z]\w*\b</string>
 			<key>name</key>
-			<string>support.module.elixir</string>
+			<string>variable.other.constant.elixir</string>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
This addresses issue #50. It occurred to me that the majority of people won’t be configuring their own color schemes. For this reason I have reverted the more descriptive `support.module` to `variable.other.constant`, which is used in most off-the-shelf themes.