### PR TITLE
Remove extra newline from def snippet

### DIFF
--- a/Snippets/def.tmSnippet
+++ b/Snippets/def.tmSnippet
@@ -5,8 +5,7 @@
 	<key>content</key>
 	<string>def $1 do
 	$0
-end
-</string>
+end</string>
 	<key>name</key>
 	<string>def</string>
 	<key>scope</key>


### PR DESCRIPTION
There's an extra newline in the def snippet and this pull request removes it.