### PR TITLE
Remove whitespace match after `do:`

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -204,7 +204,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo\b|\bwhen\b)|((,)\s*(do:?\s))|$</string>
+					<string>(\bdo\b|\bwhen\b)|((,)\s*(do:))|$</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -308,7 +308,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo\b|\bwhen\b)|((,)\s*(do:?\s))|$</string>
+					<string>(\bdo\b|\bwhen\b)|((,)\s*(do:))|$</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
This change removes an extraneous whitespace match from the `do:` component of a single line function definition. For color schemes that take advantage of the background color, this was causing the `do:` to blend into the next element..

Before:

<img width="425" alt="screen shot 2015-11-09 at 7 28 47 pm" src="https://cloud.githubusercontent.com/assets/39946/11053696/23cabbfc-8718-11e5-9087-26736bfddcf9.png">


After:

<img width="479" alt="screen shot 2015-11-09 at 7 29 41 pm" src="https://cloud.githubusercontent.com/assets/39946/11053716/42043332-8718-11e5-83bc-fac0ef804068.png">


/cc @endersstocker What do you think of this simple change?