### PR TITLE
Change snippet names with colons to use 'one line' instead

### DIFF
--- a/Snippets/if: else:.tmSnippet
+++ b/Snippets/if: else:.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>if $1, do: $2, else: $0</string>
 	<key>name</key>
-	<string>if: else:</string>
+	<string>if else (one line)</string>
 	<key>scope</key>
 	<string>source.elixir</string>
 	<key>tabTrigger</key>

--- a/Snippets/if:.tmSnippet
+++ b/Snippets/if:.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>if $1, do: $0</string>
 	<key>name</key>
-	<string>if:</string>
+	<string>if (one line)</string>
 	<key>scope</key>
 	<string>source.elixir</string>
 	<key>tabTrigger</key>

--- a/Snippets/unless: else:.tmSnippet
+++ b/Snippets/unless: else:.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>unless $1, do: $2, else: $0</string>
 	<key>name</key>
-	<string>unless: else:</string>
+	<string>unless else (one line)</string>
 	<key>scope</key>
 	<string>source.elixir</string>
 	<key>tabTrigger</key>

--- a/Snippets/unless:.tmSnippet
+++ b/Snippets/unless:.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>unless $1, do: $0</string>
 	<key>name</key>
-	<string>unless:</string>
+	<string>unless (one line)</string>
 	<key>scope</key>
 	<string>source.elixir</string>
 	<key>tabTrigger</key>


### PR DESCRIPTION
Windows breaks with colons in snippet names.

Fixes https://github.com/elixir-lang/elixir-tmbundle/issues/87.