### PR TITLE
Automatically build module name from filename in defmodule snippet

### DIFF
--- a/Snippets/defmodule.tmSnippet
+++ b/Snippets/defmodule.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>defmodule $1 do
+	<string>defmodule ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.[a-z]+)*/(?2::\u$1)/g}} do
 	$0
 end</string>
 	<key>name</key>


### PR DESCRIPTION
For example, for file `foo_bar.ex` snippet will give

    defmodule FooBar do
      
    end

instead of just 

    defmodule  do
      
    end

(Adapted from [ruby.tmbundle](https://github.com/textmate/ruby.tmbundle/blob/master/Snippets/class%20..%20end%20%20(cla).plist)).

