### PR TITLE
Highlight all SmartEngine blocks in EEX syntax

### DIFF
--- a/Syntaxes/EEx.tmLanguage
+++ b/Syntaxes/EEx.tmLanguage
@@ -30,7 +30,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>&lt;%+(?!&gt;)[-=]+</string>
+			<string>&lt;%+(?!&gt;)[=%]?</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
This fixes highlighting for `<% ... %>` and `<%% ... %>` blocks. It also removes support for the unknown `<%- %>` block.
