### PR TITLE
Highlight module names as classes

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -526,7 +526,7 @@
 					<key>match</key>
 					<string>\b[A-Z]\w*\b</string>
 					<key>name</key>
-					<string>support.type.elixir</string>
+					<string>entity.name.class.elixir</string>
 				</dict>
 				<dict>
 					<key>match</key>


### PR DESCRIPTION
This will highlight module names as classes instead of types. This will lead to the following type

```
Package.Module.function(arg)
^ entity.name.class.elixir
        ^ entity.name.class.elixir
```

Before they got highlighted as `support.type` which should be used for type definitions (for examples in other languages, see https://tmtheme-editor.herokuapp.com). This is also more consistent with the highlighting of module definitions: https://github.com/elixir-lang/elixir-tmbundle/blob/master/Syntaxes/Elixir.tmLanguage#L181