### PR TITLE
Add print_eex snippet

### DIFF
--- a/Snippets/print_eex.tmSnippet
+++ b/Snippets/print_eex.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>content</key>
+  <string>&lt;%= $0 %&gt;</string>
+  <key>name</key>
+  <string>print_eex</string>
+  <key>scope</key>
+  <string>text.elixir,text.html.elixir</string>
+  <key>tabTrigger</key>
+  <string>pe</string>
+  <key>uuid</key>
+  <string>7d07b9e0-df12-48c3-abe1-3a543878fc84</string>
+</dict>
+</plist>


### PR DESCRIPTION
This adds the `<%= %>` snippet. Usage: `pe` then TAB

Reference: https://github.com/matthewrobertson/ERB-Sublime-Snippets/blob/master/print_erb.sublime-snippet