### PR TITLE
Fix issue where some embedded Elixir didn’t match

### DIFF
--- a/Syntaxes/EEx.tmLanguage
+++ b/Syntaxes/EEx.tmLanguage
@@ -30,7 +30,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>&lt;%+(?!&gt;)[-=]+</string>
+			<string>&lt;%+(?!&gt;)[-=]*</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
Specifically, Elixir expressions (inline with output) would not match.