### PR TITLE
Auto-match `#{}` within strings

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,13 @@
+[
+  { "keys": ["#"], "command": "insert_snippet", "args": {"contents": "#{${1:$SELECTION}}$0"}, "context":
+    [
+      { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+      {
+        "operand": "(string.quoted.double.elixir | string.interpolated.elixir) - string source",
+        "operator": "equal",
+        "match_all": true,
+        "key": "selector"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
I just copied this from the Sublime Ruby package. It address #96.