### PR TITLE
sublime: string interpolation: eat typed "{" of "#{}"

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -9,5 +9,12 @@
         "key": "selector"
       }
     ]
+  },
+  { "keys": ["{"], "command": "insert", "args": {"characters": ""}, "context":
+    [
+      { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+      { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "#{$", "match_all": true }
+    ]
   }
 ]


### PR DESCRIPTION
fixes #106 