### PR TITLE
Add section comment selector

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1214,6 +1214,20 @@
 						</dict>
 					</dict>
 					<key>match</key>
+					<string>^\s*(##).*$\n?</string>
+					<key>name</key>
+					<string>comment.line.section.elixir</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.elixir</string>
+						</dict>
+					</dict>
+					<key>match</key>
 					<string>(?:^[ \t]+)?(#).*$\n?</string>
 					<key>name</key>
 					<string>comment.line.number-sign.elixir</string>


### PR DESCRIPTION
Selector `comment.line.section.elixir` matches line comments that are
conventionally used to demarcate sections, in the form:

```elixir
  ## Callbacks
```

Only matches if the comment is at the start of the line or preceeded by
whitespace. This would not match:
```elixir
42 ## The ultimate answer to life, the universe, and everything
```