### PR TITLE
Correct escaped char highlight

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1347,7 +1347,7 @@
 			<key>match</key>
 			<string>\\(x[\da-fA-F]{1,2}|.)</string>
 			<key>name</key>
-			<string>constant.character.escape.elixir</string>
+			<string>constant.character.escaped.elixir</string>
 		</dict>
 		<key>interpolated_elixir</key>
 		<dict>


### PR DESCRIPTION
Before:
![sp160925_113016](https://cloud.githubusercontent.com/assets/1329716/18812316/7c6adf4c-8313-11e6-8c43-247341d68b0d.png)

After:
![sp160925_112939](https://cloud.githubusercontent.com/assets/1329716/18812317/80c85d1c-8313-11e6-823e-53c3b30fe556.png)
