### PR TITLE
Stop special-casing `when`

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -204,7 +204,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b|\bwhen\b)|$</string>
+					<string>(\bdo:)|(\bdo\b)|$</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -303,7 +303,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b|\bwhen\b)|$</string>
+					<string>(\bdo:)|(\bdo\b)|$</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
The syntax highlighting for `when` has being ambiguous and confusing.
This PR fixes the highlighting by removing the special highlighting for `when` in `def` and `defp`

Before:
![sp161005_091841](https://cloud.githubusercontent.com/assets/1329716/19094643/ca1b4486-8adc-11e6-8a03-2abbb73cf19a.png)

After:
![sp161005_091728](https://cloud.githubusercontent.com/assets/1329716/19094596/9002885e-8adc-11e6-8e71-f9485cb4f03a.png)

Also, `when`s following `defmacro` and `defmacrop` are not special-cased, they look like "After".
