### PR TITLE
Add Sublime Text's global symbol list support

### DIFF
--- a/Preferences/Symbol List - Module.tmPreferences
+++ b/Preferences/Symbol List - Module.tmPreferences
@@ -12,10 +12,10 @@
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>
-		s/defmodule\s+//;
-		s/do//;
-		s/\s//g;
-	</string>
+			s/defmodule\s+//;
+			s/do//;
+			s/\s//g;
+		</string>
 	</dict>
 	<key>uuid</key>
 	<string>7FF38726-C866-419E-A79C-1323948E6800</string>

--- a/Preferences/Symbol List - Module.tmPreferences
+++ b/Preferences/Symbol List - Module.tmPreferences
@@ -10,11 +10,17 @@
 	<dict>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
+		<key>showInIndexedSymbolList</key>
+		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>
 			s/defmodule\s+//;
 			s/do//;
 			s/\s//g;
+		</string>
+		<key>symbolIndexTransformation</key>
+		<string>
+			s/(defmodule|do)//g;
 		</string>
 	</dict>
 	<key>uuid</key>

--- a/Preferences/Symbol List - Private Function.tmPreferences
+++ b/Preferences/Symbol List - Private Function.tmPreferences
@@ -10,6 +10,8 @@
 	<dict>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
+		<key>showInIndexedSymbolList</key>
+		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>s/(.*)/ $1  (private)/</string>
 	</dict>


### PR DESCRIPTION
Sublime Text 3 has two types of symbol lists: local (for current file) and global (for whole project). Global list allows you to jump to definition of module or function from anywhere in the project.
This repo already supports local list and the PR adds support for global one.

I've checked this with TextMate 2 and Sublime Text 3, it seems like everything works fine.