### PR TITLE
Support multi-line function head

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -204,7 +204,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b)|$</string>
+					<string>(\bdo:)|(\bdo\b)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -303,7 +303,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b)|$</string>
+					<string>(\bdo:)|(\bdo\b)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
This PR enables proper syntax highlighting for function heads that span multiple lines!

All we need to change is the `end` regex for `def` and `defp` so that we end the function head section when we see `do` or `do:`, but not when we reach the end of a line `$`, as we currently do

Before:

![screen shot 2017-01-22 at 4 27 12 pm](https://cloud.githubusercontent.com/assets/39946/22187708/09a5bfd0-e0c0-11e6-8993-3ecc3bef6945.png)


After

![screen shot 2017-01-22 at 4 26 49 pm](https://cloud.githubusercontent.com/assets/39946/22187711/10f50a5c-e0c0-11e6-9209-1579af5d73be.png)

This seems like it's been an issue for some time https://github.com/elixir-lang/elixir-tmbundle/issues/83