### PR TITLE
Add guard clause highlighting

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -275,6 +275,12 @@
 						</dict>
 						<dict>
 							<key>match</key>
+							<string>\b(is_atom|is_binary|is_bitstring|is_boolean|is_float|is_function|is_integer|is_list|is_map|is_nil|is_number|is_pid|is_port|is_record|is_reference|is_tuple|is_exception|abs|bit_size|byte_size|div|elem|hd|length|map_size|node|rem|round|tl|trunc|tuple_size)\b</string>
+							<key>name</key>
+							<string>keyword.control.elixir</string>
+						</dict>
+						<dict>
+							<key>match</key>
 							<string>\b[a-z_]\w*\b</string>
 							<key>name</key>
 							<string>variable.parameter.function.public.elixir</string>
@@ -371,6 +377,12 @@
 									<string>$self</string>
 								</dict>
 							</array>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\b(is_atom|is_binary|is_bitstring|is_boolean|is_float|is_function|is_integer|is_list|is_map|is_nil|is_number|is_pid|is_port|is_record|is_reference|is_tuple|is_exception|abs|bit_size|byte_size|div|elem|hd|length|map_size|node|rem|round|tl|trunc|tuple_size)\b</string>
+							<key>name</key>
+							<string>keyword.control.elixir</string>
 						</dict>
 						<dict>
 							<key>match</key>


### PR DESCRIPTION
This adds in highlighting for guard clauses inside of a function head definition.

Before this PR, guard clauses get picked up as function parameters:

![screen shot 2017-01-22 at 4 52 04 pm](https://cloud.githubusercontent.com/assets/39946/22187906/3fc3cc62-e0c3-11e6-8b65-9ec205117bf7.png)

After, they are categorized as `keyword`:

![screen shot 2017-01-22 at 4 52 13 pm](https://cloud.githubusercontent.com/assets/39946/22187911/4d716770-e0c3-11e6-9b80-837c8e033358.png)

From what I can tell, the `vim` syntax has this already: https://github.com/elixir-lang/vim-elixir/blob/master/syntax/elixir.vim#L26-L27