### PR TITLE
Highlight defmacro function head like def

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -184,7 +184,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*(def)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
+					<string>^\s*(def|defmacro)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -283,7 +283,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*(defp)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
+					<string>^\s*(defp|defmacrop)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
This PR makes sure that the function head for `defmacro` gets highlighted in the same way as a normal function with `def`. Also for `defmacrop`

Before:

![screen shot 2017-01-22 at 5 14 49 pm](https://cloud.githubusercontent.com/assets/39946/22188161/4359472c-e0c7-11e6-86f5-d22429f29445.png)

After:

![screen shot 2017-01-22 at 5 15 13 pm](https://cloud.githubusercontent.com/assets/39946/22188166/4c12d64e-e0c7-11e6-9b69-909405afecbe.png)


