### PR TITLE
Properly close capture for default arguments

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -307,7 +307,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>,|$</string>
+							<string>,|\)|$</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -412,7 +412,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>,|$</string>
+							<string>,|\)|$</string>
 							<key>patterns</key>
 							<array>
 								<dict>


### PR DESCRIPTION
I noticed that functions with default arguments `\\` are getting a bit confused, as they don't stop matching function parameters properly. This PR fixes that.

Before:

<img width="412" alt="screen shot 2017-02-01 at 5 18 26 pm" src="https://cloud.githubusercontent.com/assets/39946/22533473/3c88f918-e8a3-11e6-82e6-fe0c80bc5b05.png">

After:

<img width="414" alt="screen shot 2017-02-01 at 5 19 44 pm" src="https://cloud.githubusercontent.com/assets/39946/22533487/50c0f44e-e8a3-11e6-9c52-6f5e52fa2a54.png">


This was last touched here: https://github.com/elixir-lang/elixir-tmbundle/pull/69. I made sure to include the example syntax that was given in that PR as well

cc/ @endersstocker