### PR TITLE
Fix highlighting for function with header

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -273,7 +273,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b)</string>
+					<string>(\bdo:)|(\bdo\b)|(?=\s+(def|defmacro)\b)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -378,7 +378,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b)</string>
+					<string>(\bdo:)|(\bdo\b)|(?=\s+(defp|defmacrop)\b)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Fixes #123 

Tested with:

```elixir
defmodule Legacy.ExtraAsserts do
  def assert_date_approx1(date1,
    date2,
    ms_delta \\ 100)
  def assert_date_approx1(date1,
    date2,
    ms_delta) do
    assert_in_delta(date1_ms, date2_ms, ms_delta)
  end

  defp assert_date_approx(date1,
    date2,
    ms_delta \\ 100)

  defp assert_date_approx(date1,
    date2,
    ms_delta) do
    assert_in_delta(date1_ms, date2_ms, ms_delta)
  end

  defp one_line(date1, date2, blah \\ :ok)
  defp one_line(date1, date2, blah) do
    cool(date1, date2, blah)
  end
end
```