### PR TITLE
TextMate 2 bundle’s directory update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ Type the following commands to setup the bundle for **TextMate**:
 If you are using **TextMate 2**, type the following commands in your shell:
 
     mkdir -p ~/Library/Application\ Support/Avian/Bundles
-    cd ~/Library/Application\ Support/Avian/Bundles
+    cd ~/Library/Application\ Support/TextMate/Bundles
     git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
 
 


### PR DESCRIPTION
It changed back to the same as 1.x: https://github.com/textmate/textmate/commit/3a8f524803b56cfa3791e605356e8a31fb8b5072