### PR TITLE
Update TextMate 2 Bundle directory.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ Type the following commands to setup the bundle for **TextMate**:
 
 If you are using **TextMate 2**, type the following commands in your shell:
 
-    mkdir -p ~/Library/Application\ Support/Avian/Bundles
+    mkdir -p ~/Library/Application\ Support/TextMate/Bundles
     cd ~/Library/Application\ Support/TextMate/Bundles
     git clone git://github.com/elixir-lang/elixir-tmbundle Elixir.tmbundle
 


### PR DESCRIPTION
https://github.com/textmate/textmate/blob/master/Applications/TextMate/about/Changes.md#2016-10-11-v20-beta1223

> "Bundles are no longer read from the Avian folder."